### PR TITLE
Update Airflow Settings on Docker Compose

### DIFF
--- a/docker-compose-por-aula/aula-09.yml
+++ b/docker-compose-por-aula/aula-09.yml
@@ -49,8 +49,8 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -61,8 +61,8 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-09.yml
+++ b/docker-compose-por-aula/aula-09.yml
@@ -32,7 +32,7 @@ x-awari-airflow-depends-on: &awari-airflow-depends-on
 services:
   # Airflow Services
   awari-airflow-postgres:
-    image: postgres:latest
+    image: postgres:12
     container_name: awari-airflow-postgres
     ports:
       - "5434:5432"
@@ -49,8 +49,7 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -61,8 +60,7 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-10.yml
+++ b/docker-compose-por-aula/aula-10.yml
@@ -108,7 +108,7 @@ services:
 
   # Airflow Services
   awari-airflow-postgres:
-    image: postgres:latest
+    image: postgres:12
     container_name: awari-airflow-postgres
     ports:
       - "5434:5432"
@@ -125,8 +125,7 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +136,7 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-10.yml
+++ b/docker-compose-por-aula/aula-10.yml
@@ -125,8 +125,8 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +137,8 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-11.yml
+++ b/docker-compose-por-aula/aula-11.yml
@@ -108,7 +108,7 @@ services:
 
   # Airflow Services
   awari-airflow-postgres:
-    image: postgres:latest
+    image: postgres:12
     container_name: awari-airflow-postgres
     ports:
       - "5434:5432"
@@ -125,8 +125,7 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +136,7 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-11.yml
+++ b/docker-compose-por-aula/aula-11.yml
@@ -125,8 +125,8 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +137,8 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-12.yml
+++ b/docker-compose-por-aula/aula-12.yml
@@ -108,7 +108,7 @@ services:
 
   # Airflow Services
   awari-airflow-postgres:
-    image: postgres:latest
+    image: postgres:12
     container_name: awari-airflow-postgres
     ports:
       - "5434:5432"
@@ -125,8 +125,7 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +136,7 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    - <<: *awari-airflow-common
-    - <<: *awari-airflow-depends-on
+    <<: [*awari-airflow-common, *awari-airflow-depends-on]
     container_name: awari-airflow-webserver
     restart: always
     command: webserver

--- a/docker-compose-por-aula/aula-12.yml
+++ b/docker-compose-por-aula/aula-12.yml
@@ -125,8 +125,8 @@ services:
         ipv4_address: 172.18.0.110
 
   awari-airflow-scheduler:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-scheduler
     command: scheduler
     restart: on-failure
@@ -137,8 +137,8 @@ services:
         ipv4_address: 172.18.0.111
 
   awari-airflow-webserver:
-    <<: *awari-airflow-common
-    <<: *awari-airflow-depends-on
+    - <<: *awari-airflow-common
+    - <<: *awari-airflow-depends-on
     container_name: awari-airflow-webserver
     restart: always
     command: webserver


### PR DESCRIPTION
## Contexto:

Correção nas dependências `awari-airflow-common` e `awari-airflow-depends-on` nas configurações do Airflow Scheduler e Airflow Webserver, além de ajustes de compatibilidade no banco de dados do Airflow.

# Alterações realizadas:
- Adição de lista ao referenciar as dependências do `airflow-scheduler` e `airflow-webserver` nos arquivos de docker compose das aulas 9, 10, 11 e 12;
- Ajuste da versão do postgres usada como banco de dados do Airflow, usando a versão 12 como padrão evitando problemas de compatibilidade.